### PR TITLE
Sample of bulk insert

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -16,10 +16,11 @@ type ResultBackend interface {
 // ResultSet represents the set of results from an individual
 // job that's executed.
 type ResultSet interface {
-	RegisterColTypes([]string, []*sql.ColumnType) error
+	RegisterColTypes([]string, []*sql.ColumnType, int) error
 	IsColTypesRegistered() bool
 	WriteCols([]string) error
 	WriteRow([]interface{}) error
+	WriteRowBulk([]interface{}) error
 	Flush() error
 	Close() error
 }

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -20,7 +20,8 @@ type ResultSet interface {
 	IsColTypesRegistered() bool
 	WriteCols([]string) error
 	WriteRow([]interface{}) error
-	WriteRowBulk([]interface{}) error
+	WriteRowBulkDefault([]interface{}) error
+	WriteRowBulk(rows []interface{}, batchSize int64) error
 	Flush() error
 	Close() error
 }


### PR DESCRIPTION
Hi!

- What exactly is changing? In jobber.go the writeResult change to consider interate the origin source and batch to the target database using new methods of the backend that use SQL with insert multlples rows. It hence that pass a slice to the backend method and there split acording the batch size.

- why? Some bulks of thousands of lines could speedup if some bulk "backend" methods its used.

- and how it helps? By configuration, could speedup the velocity of insert in target database.

- The overall architecture. 
1. In the main loop, organize the iteration from origin to append the result to send to backend.
2. The backend build SQL in inserts with multiple lines.

TODO:
1. Move the batch size to configuration.
3. If [pull 21](https://github.com/knadh/sql-jobber/pull/21) it's merged before, add some test
